### PR TITLE
Simplify renderer to basic Todo list

### DIFF
--- a/mr-mime/src/__tests__/App.test.tsx
+++ b/mr-mime/src/__tests__/App.test.tsx
@@ -1,9 +1,20 @@
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import App from '../renderer/App';
 
-describe('App', () => {
-  it('should render', () => {
-    expect(render(<App />)).toBeTruthy();
+describe('TodoList', () => {
+  it('allows items to be added and removed', () => {
+    render(<App />);
+
+    const input = screen.getByPlaceholderText(/add todo/i);
+    const addButton = screen.getByText(/add/i);
+
+    fireEvent.change(input, { target: { value: 'First' } });
+    fireEvent.click(addButton);
+    expect(screen.getByText('First')).toBeInTheDocument();
+
+    const removeButton = screen.getByText(/remove/i);
+    fireEvent.click(removeButton);
+    expect(screen.queryByText('First')).not.toBeInTheDocument();
   });
 });

--- a/mr-mime/src/renderer/App.tsx
+++ b/mr-mime/src/renderer/App.tsx
@@ -1,50 +1,6 @@
-import { MemoryRouter as Router, Routes, Route } from 'react-router-dom';
-import icon from '../../assets/icon.svg';
 import './App.css';
-
-function Hello() {
-  return (
-    <div>
-      <div className="Hello">
-        <img width="200" alt="icon" src={icon} />
-      </div>
-      <h1>electron-react-boilerplate</h1>
-      <div className="Hello">
-        <a
-          href="https://electron-react-boilerplate.js.org/"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <button type="button">
-            <span role="img" aria-label="books">
-              📚
-            </span>
-            Read our docs
-          </button>
-        </a>
-        <a
-          href="https://github.com/sponsors/electron-react-boilerplate"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <button type="button">
-            <span role="img" aria-label="folded hands">
-              🙏
-            </span>
-            Donate
-          </button>
-        </a>
-      </div>
-    </div>
-  );
-}
+import TodoList from './TodoList';
 
 export default function App() {
-  return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Hello />} />
-      </Routes>
-    </Router>
-  );
+  return <TodoList />;
 }

--- a/mr-mime/src/renderer/TodoList.tsx
+++ b/mr-mime/src/renderer/TodoList.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+export default function TodoList() {
+  const [items, setItems] = useState<string[]>([]);
+  const [text, setText] = useState('');
+
+  const addItem = () => {
+    const value = text.trim();
+    if (value) {
+      setItems([...items, value]);
+      setText('');
+    }
+  };
+
+  const removeItem = (index: number) => {
+    setItems(items.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div>
+      <input
+        placeholder="Add todo"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <button type="button" onClick={addItem}>
+        Add
+      </button>
+      <ul>
+        {items.map((item, index) => (
+          <li key={item}>
+            {item}
+            <button type="button" onClick={() => removeItem(index)}>
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace boilerplate app with a simple Todo list
- add new `TodoList` component
- test adding and removing todos

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872f92647908332a5ccda6e5381efe2